### PR TITLE
Add bulk update dialog for tasks

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -37,10 +37,12 @@ class MainWindow(QMainWindow):
         from ui.today_view import TodayView
         from ui.calendar_view import CalendarView
         from ui.tasks_view import TasksView
+        from ui.reports_view import ReportsView
 
         tabs.addTab(TodayView(conn), "Dziś")
         tabs.addTab(CalendarView(conn), "Kalendarz")
         tabs.addTab(TasksView(conn), "Zadania")
+        tabs.addTab(ReportsView(conn), "Raporty")
         self.setCentralWidget(tabs)
 
 
@@ -48,6 +50,7 @@ def main() -> int:
     config = load_config()
     plain = Path(config["db_plain_path"])
     enc = Path(config["db_encrypted_path"])
+    plain.parent.mkdir(parents=True, exist_ok=True)
     backup_dir = Path(config["backup_path"])
 
     if enc.exists():

--- a/src/ui/reports_view.py
+++ b/src/ui/reports_view.py
@@ -1,0 +1,27 @@
+"""Simple Reports view showing weekly task stats."""
+from __future__ import annotations
+
+from datetime import date
+from PySide6.QtWidgets import QVBoxLayout, QWidget, QLabel
+
+from services.tasks_service import get_tasks_for_week
+from services.week_service import iso_week
+
+
+class ReportsView(QWidget):
+    """Display basic statistics about tasks for the current week."""
+
+    def __init__(self, conn):
+        super().__init__()
+
+        self.conn = conn
+        layout = QVBoxLayout()
+
+        curr_week = iso_week(date.today())
+        rows = get_tasks_for_week(conn, curr_week)
+        total = len(rows)
+        done = sum(1 for r in rows if r["status"] == "DONE")
+        text = f"Zadania: {done}/{total} ukończone w tym tygodniu"
+        layout.addWidget(QLabel(text))
+
+        self.setLayout(layout)

--- a/src/ui/tasks_view.py
+++ b/src/ui/tasks_view.py
@@ -1,4 +1,3 @@
-
 """Simple Kanban board with ability to add tasks."""
 from __future__ import annotations
 
@@ -6,7 +5,6 @@ from datetime import date
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QHBoxLayout,
-    QLineEdit,
     QListWidget,
     QListWidgetItem,
     QPushButton,
@@ -19,12 +17,18 @@ from services.tasks_service import (
     assign_to_week,
     get_or_create_default_project,
     get_tasks_for_week,
+    bulk_update,
     update_status,
 )
 from services.week_service import iso_week
 
+from .widgets.add_task_dialog import AddTaskDialog
+from .widgets.bulk_update_dialog import BulkUpdateDialog
+
 
 class StatusList(QListWidget):
+    """List widget representing a task status column."""
+
     def __init__(self, status: str, on_change):
         super().__init__()
         self.status = status
@@ -34,25 +38,17 @@ class StatusList(QListWidget):
         self.setDefaultDropAction(Qt.MoveAction)
         self.setSelectionMode(QListWidget.SingleSelection)
 
-    def dropEvent(self, event):
+    def dropEvent(self, event):  # noqa: N802 - Qt override
         item = self.currentItem()
         super().dropEvent(event)
         if item:
             task_id = item.data(Qt.UserRole)
             self.on_change(task_id, self.status)
 
-=======
-"""Simple Kanban placeholder."""
-from __future__ import annotations
-
-from PySide6.QtWidgets import (
-    QHBoxLayout,
-    QListWidget,
-    QWidget,
-)
-
 
 class TasksView(QWidget):
+    """Kanban board view with an option to add tasks."""
+
     def __init__(self, conn):
         super().__init__()
 
@@ -61,22 +57,26 @@ class TasksView(QWidget):
         self.project_id = get_or_create_default_project(conn)
 
         main = QVBoxLayout()
+
         board = QHBoxLayout()
-        self.lists = {}
+        self.lists: dict[str, StatusList] = {}
         for name in ["TODO", "IN_PROGRESS", "DONE"]:
             lst = StatusList(name, self._status_changed)
             board.addWidget(lst)
             self.lists[name] = lst
         main.addLayout(board)
 
-        form = QHBoxLayout()
-        self.title_edit = QLineEdit()
-        self.title_edit.setPlaceholderText("Nowe zadanie")
-        add_btn = QPushButton("Dodaj")
+        actions = QHBoxLayout()
+
+        add_btn = QPushButton("Dodaj zadanie")
         add_btn.clicked.connect(self._add_task)
-        form.addWidget(self.title_edit)
-        form.addWidget(add_btn)
-        main.addLayout(form)
+        actions.addWidget(add_btn)
+
+        bulk_btn = QPushButton("Masowa aktualizacja")
+        bulk_btn.clicked.connect(self._bulk_update)
+        actions.addWidget(bulk_btn)
+
+        main.addLayout(actions)
 
         self.setLayout(main)
         self._load_tasks()
@@ -90,23 +90,35 @@ class TasksView(QWidget):
             self.lists[row["status"]].addItem(item)
 
     def _add_task(self) -> None:
-        title = self.title_edit.text().strip()
-        if not title:
+        dlg = AddTaskDialog(self)
+        if dlg.exec() != dlg.Accepted:
             return
-        task_id = add_task(self.conn, self.project_id, title)
+        data = dlg.get_data()
+        if not data["title"]:
+            return
+        task_id = add_task(
+            self.conn,
+            self.project_id,
+            data["title"],
+            data["priority"],
+            data["estimate"],
+            data["notes"],
+        )
         assign_to_week(self.conn, task_id, self.curr_week)
-        item = QListWidgetItem(title)
+        item = QListWidgetItem(data["title"])
         item.setData(Qt.UserRole, task_id)
         self.lists["TODO"].addItem(item)
-        self.title_edit.clear()
 
     def _status_changed(self, task_id: int, status: str) -> None:
         update_status(self.conn, task_id, status)
 
-        layout = QHBoxLayout()
-        for name in ["TODO", "IN_PROGRESS", "DONE"]:
-            lst = QListWidget()
-            lst.setObjectName(name)
-            lst.setDragDropMode(QListWidget.InternalMove)
-            layout.addWidget(lst)
-        self.setLayout(layout)
+    def _bulk_update(self) -> None:
+        dlg = BulkUpdateDialog(self)
+        if dlg.exec() != dlg.Accepted:
+            return
+        tasks = dlg.get_tasks()
+        if not tasks:
+            return
+        bulk_update(self.conn, tasks)
+        self._load_tasks()
+

--- a/src/ui/widgets/add_task_dialog.py
+++ b/src/ui/widgets/add_task_dialog.py
@@ -1,0 +1,56 @@
+"""Dialog window for creating a new task."""
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+    QSpinBox,
+    QTextEdit,
+)
+
+
+class AddTaskDialog(QDialog):
+    """Collect all information required to create a task."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Nowe zadanie")
+
+        layout = QFormLayout()
+
+        self.title_edit = QLineEdit()
+        layout.addRow("Tytuł", self.title_edit)
+
+        self.priority_spin = QSpinBox()
+        self.priority_spin.setRange(1, 5)
+        self.priority_spin.setValue(3)
+        layout.addRow("Priorytet", self.priority_spin)
+
+        self.estimate_spin = QSpinBox()
+        self.estimate_spin.setRange(0, 100)
+        self.estimate_spin.setSpecialValueText("")
+        layout.addRow("Szac. czas", self.estimate_spin)
+
+        self.notes_edit = QTextEdit()
+        layout.addRow("Notatki", self.notes_edit)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=self
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.setLayout(layout)
+
+    def get_data(self) -> dict:
+        """Return the data entered by the user."""
+        return {
+            "title": self.title_edit.text().strip(),
+            "priority": self.priority_spin.value(),
+            "estimate": self.estimate_spin.value() or None,
+            "notes": self.notes_edit.toPlainText().strip() or None,
+        }
+

--- a/src/ui/widgets/bulk_update_dialog.py
+++ b/src/ui/widgets/bulk_update_dialog.py
@@ -1,0 +1,51 @@
+"""Dialog window allowing mass task updates via JSON."""
+from __future__ import annotations
+
+import json
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QTextEdit,
+    QVBoxLayout,
+)
+
+
+class BulkUpdateDialog(QDialog):
+    """Prompt user for JSON describing tasks to add or update."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Masowa aktualizacja")
+
+        layout = QVBoxLayout()
+
+        fmt = (
+            "Format:\n{\n  \"tasks\": [\n    {\"title\": \"Nowe\", \"week\": \"2024-W30\"},\n"
+            "    {\"id\": 1, \"status\": \"DONE\"}\n  ]\n}"
+        )
+        info = QLabel(fmt)
+        info.setWordWrap(True)
+        layout.addWidget(info)
+
+        self.text = QTextEdit()
+        layout.addWidget(self.text)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.setLayout(layout)
+
+    def get_tasks(self) -> list[dict]:
+        """Return parsed task data or an empty list on failure."""
+        try:
+            data = json.loads(self.text.toPlainText() or "{}")
+        except json.JSONDecodeError:
+            return []
+        if isinstance(data, dict):
+            tasks = data.get("tasks", [])
+            if isinstance(tasks, list):
+                return [t for t in tasks if isinstance(t, dict)]
+        return []


### PR DESCRIPTION
## Summary
- support mass creation and updates of tasks with new `bulk_update` service
- add `BulkUpdateDialog` explaining JSON format for mass edits
- expose a "Masowa aktualizacja" button in `TasksView` to apply JSON updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5fa9c855883319638cc4ed0d56814